### PR TITLE
correct way to install directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["internal", "utils"]
+include = ["internal*", "utils*"]
 
 [project]
 name = "gaussian-splatting-lightning"


### PR DESCRIPTION
@yzslab I have made changes in `pyproject.toml` to correctly install all directories. If `*` is not included then it will only consider scripts in `internal` directory but not all sub directories.