### PR TITLE
Fix sd feature extractor extensions parser

### DIFF
--- a/utils/sd_feature_extraction.py
+++ b/utils/sd_feature_extraction.py
@@ -269,7 +269,7 @@ def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("image_dir", type=str)
     parser.add_argument("--output", "-o", type=str, default=None)
-    parser.add_argument("--extensions", "-e", type=str, default=["jpg", "JPG", "jpeg", "JPEG"])
+    parser.add_argument("--extensions", "-e", nargs="+", type=str, default=["jpg", "JPG", "jpeg", "JPEG"])
     parser.add_argument("--image-size", "-s", type=int, default=800)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--image_list", "--image-list", type=str, default=None)


### PR DESCRIPTION
Passing the extensions flag results in a string being parsed for the extensions, rather than a list of strings (like the default). 

The result is that downstream, no images are found. This fixes the issue.