### PR TITLE
Allow converting image from np.uint16 from polycam

### DIFF
--- a/utils/polycam2points.py
+++ b/utils/polycam2points.py
@@ -60,7 +60,7 @@ for image_idx in tqdm(range(len(image_set))):
 
     # build points
     points = depth_map_to_points(
-        torch.tensor(depth, dtype=torch.float) * 1e-3 * args.scale,
+        torch.tensor(depth.astype(np.float32), dtype=torch.float) * 1e-3 * args.scale,
         fx=camera.fx / scale_factor_x,
         fy=camera.fy / scale_factor_y,
         cx=camera.cx / scale_factor_x,


### PR DESCRIPTION
In some cases, the `depth` read from polycam will be of type `np.uint16`, which is not supported by pytorch to convert to float.

In these cases, a TypeError will raise as:

> TypeError: can't convert np.ndarray of type numpy.uint16. The only supported types are: float64, float32, float16, complex64, complex128, int64, int32, int16, int8, uint8, and bool.